### PR TITLE
[Style] #13 - 모임 더 둘러보기 화면, 네비게이션바 구현

### DIFF
--- a/Carrot-iOS/Carrot-iOS/Presentation/Club/ViewController/ClubViewController.swift
+++ b/Carrot-iOS/Carrot-iOS/Presentation/Club/ViewController/ClubViewController.swift
@@ -15,7 +15,6 @@ final class ClubViewController: UIViewController {
     // MARK: - Properties
     
     private let profileButton = UIBarButtonItem(image: UIImage(named: "ic_profile"), style: .plain, target: self, action: nil)
-    private let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
     private let alarmButton = UIBarButtonItem(image: UIImage(named: "ic_alarm"), style: .plain, target: self, action: nil)
     private let searchBar = UISearchBar()
     
@@ -69,13 +68,13 @@ extension ClubViewController {
             $0.top.equalToSuperview().inset(90)
             $0.leading.trailing.equalToSuperview().inset(15)
         }
-        
     }
     
     private func setNavigation() {
         navigationItem.rightBarButtonItems = [alarmButton, profileButton]
         self.navigationController?.navigationBar.topItem?.title = "동천동 모임"
         self.navigationController?.navigationBar.tintColor = .black
+        self.navigationController?.navigationBar.topItem?.backButtonTitle = ""
     }
     
 }

--- a/Carrot-iOS/Carrot-iOS/Presentation/Club/ViewController/ClubViewController.swift
+++ b/Carrot-iOS/Carrot-iOS/Presentation/Club/ViewController/ClubViewController.swift
@@ -14,7 +14,10 @@ final class ClubViewController: UIViewController {
     
     // MARK: - Properties
     
-    let searchBar = UISearchBar()
+    private let profileButton = UIBarButtonItem(image: UIImage(named: "ic_profile"), style: .plain, target: self, action: nil)
+    private let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
+    private let alarmButton = UIBarButtonItem(image: UIImage(named: "ic_alarm"), style: .plain, target: self, action: nil)
+    private let searchBar = UISearchBar()
     
     // MARK: - View Life Cycle
     
@@ -22,6 +25,7 @@ final class ClubViewController: UIViewController {
         super.viewDidLoad()
         
         view.backgroundColor = .white
+        setNavigation()
         setUI()
     }
 
@@ -48,8 +52,30 @@ extension ClubViewController {
             $0.searchTextField.layer.cornerRadius = 5
             $0.searchTextField.layer.masksToBounds = true
         }
+        
+        profileButton.do {
+            $0.imageInsets = UIEdgeInsets(top: 0, left: 30, bottom: 0, right: 0)
+        }
+        
+        alarmButton.do {
+            $0.imageInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        }
     }
     
-    private func setLayout() {}
+    private func setLayout() {
+        view.addSubview(searchBar)
+        
+        searchBar.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(90)
+            $0.leading.trailing.equalToSuperview().inset(15)
+        }
+        
+    }
+    
+    private func setNavigation() {
+        navigationItem.rightBarButtonItems = [alarmButton, profileButton]
+        self.navigationController?.navigationBar.topItem?.title = "동천동 모임"
+        self.navigationController?.navigationBar.tintColor = .black
+    }
     
 }


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #13 

### ✅ 작업한 내용
- 네비게이션 바 아이템 추가
- 네비게이션 바 뒤로가기 버튼 커스텀

### ❗️PR Point
- 없습니다.

### 📸 스크린샷
<img src="https://github.com/DOSOPT-CDS-APP-TEAM5/Carrot-iOS/assets/124351800/2b9361e2-f2b6-4f80-9a52-95063ccc72b6" alt="이미지 설명" width="450" height="975">

closed #13
