### PR TITLE
[Style] #24 - 모임 가입하기 화면, 상단 배너 구현

### DIFF
--- a/Carrot-iOS/Carrot-iOS.xcodeproj/project.pbxproj
+++ b/Carrot-iOS/Carrot-iOS.xcodeproj/project.pbxproj
@@ -18,8 +18,6 @@
 		007BAC992B08A6CC005A34C3 /* 11.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007BAC982B08A6CC005A34C3 /* 11.swift */; };
 		007BAC9B2B08A6D0005A34C3 /* 12.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007BAC9A2B08A6D0005A34C3 /* 12.swift */; };
 		007BAC9F2B08A6E4005A34C3 /* 14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007BAC9E2B08A6E4005A34C3 /* 14.swift */; };
-		007BACA12B08A6E8005A34C3 /* 15.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007BACA02B08A6E8005A34C3 /* 15.swift */; };
-		007BACA32B08A6ED005A34C3 /* 16.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007BACA22B08A6ED005A34C3 /* 16.swift */; };
 		007BACA52B08A6F4005A34C3 /* 17.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007BACA42B08A6F4005A34C3 /* 17.swift */; };
 		007BACA72B08A6FB005A34C3 /* 18.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007BACA62B08A6FB005A34C3 /* 18.swift */; };
 		007BACA92B08A703005A34C3 /* 19.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007BACA82B08A703005A34C3 /* 19.swift */; };
@@ -29,6 +27,10 @@
 		007BACBB2B08A79E005A34C3 /* 4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007BACBA2B08A79E005A34C3 /* 4.swift */; };
 		0083B1A22B0BCAA500357725 /* ClubViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0083B1A12B0BCAA500357725 /* ClubViewController.swift */; };
 		39334A4C2B0C6EFE00A17275 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39334A4B2B0C6EFE00A17275 /* UIFont+.swift */; };
+		39D1EEC12B0DEA3900A1A779 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D1EEC02B0DEA3900A1A779 /* DetailViewController.swift */; };
+		39D1EEC32B0DEA6900A1A779 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D1EEC22B0DEA6900A1A779 /* DetailView.swift */; };
+		39D1EEC62B0DED6700A1A779 /* DetailTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D1EEC52B0DED6700A1A779 /* DetailTopView.swift */; };
+		39D1EEC82B0DEEE500A1A779 /* DetailBannerImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D1EEC72B0DEEE500A1A779 /* DetailBannerImageView.swift */; };
 		39FE56752B0DA82600A17A03 /* AppleSDGothicNeo.ttc in Resources */ = {isa = PBXBuildFile; fileRef = 39FE56732B0DA82600A17A03 /* AppleSDGothicNeo.ttc */; };
 		39FE56762B0DA82600A17A03 /* SF-Pro.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 39FE56742B0DA82600A17A03 /* SF-Pro.ttf */; };
 		D206CA582B0C5B9E007ECC1B /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D206CA572B0C5B9E007ECC1B /* MainViewController.swift */; };
@@ -77,8 +79,6 @@
 		007BAC982B08A6CC005A34C3 /* 11.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 11.swift; sourceTree = "<group>"; };
 		007BAC9A2B08A6D0005A34C3 /* 12.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 12.swift; sourceTree = "<group>"; };
 		007BAC9E2B08A6E4005A34C3 /* 14.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 14.swift; sourceTree = "<group>"; };
-		007BACA02B08A6E8005A34C3 /* 15.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 15.swift; sourceTree = "<group>"; };
-		007BACA22B08A6ED005A34C3 /* 16.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 16.swift; sourceTree = "<group>"; };
 		007BACA42B08A6F4005A34C3 /* 17.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 17.swift; sourceTree = "<group>"; };
 		007BACA62B08A6FB005A34C3 /* 18.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 18.swift; sourceTree = "<group>"; };
 		007BACA82B08A703005A34C3 /* 19.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 19.swift; sourceTree = "<group>"; };
@@ -88,6 +88,10 @@
 		007BACBA2B08A79E005A34C3 /* 4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 4.swift; sourceTree = "<group>"; };
 		0083B1A12B0BCAA500357725 /* ClubViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubViewController.swift; sourceTree = "<group>"; };
 		39334A4B2B0C6EFE00A17275 /* UIFont+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
+		39D1EEC02B0DEA3900A1A779 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
+		39D1EEC22B0DEA6900A1A779 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
+		39D1EEC52B0DED6700A1A779 /* DetailTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailTopView.swift; sourceTree = "<group>"; };
+		39D1EEC72B0DEEE500A1A779 /* DetailBannerImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailBannerImageView.swift; sourceTree = "<group>"; };
 		39FE56732B0DA82600A17A03 /* AppleSDGothicNeo.ttc */ = {isa = PBXFileReference; lastKnownFileType = file; path = AppleSDGothicNeo.ttc; sourceTree = "<group>"; };
 		39FE56742B0DA82600A17A03 /* SF-Pro.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SF-Pro.ttf"; sourceTree = "<group>"; };
 		D206CA572B0C5B9E007ECC1B /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
@@ -351,7 +355,7 @@
 		007BAC8C2B08A63C005A34C3 /* ViewController */ = {
 			isa = PBXGroup;
 			children = (
-				007BACA22B08A6ED005A34C3 /* 16.swift */,
+				39D1EEC02B0DEA3900A1A779 /* DetailViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -359,7 +363,8 @@
 		007BAC8D2B08A644005A34C3 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				007BACA02B08A6E8005A34C3 /* 15.swift */,
+				39D1EEC42B0DED4900A1A779 /* AssistantView */,
+				39D1EEC22B0DEA6900A1A779 /* DetailView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -426,6 +431,15 @@
 				007BACBA2B08A79E005A34C3 /* 4.swift */,
 			);
 			path = SignUp;
+			sourceTree = "<group>";
+		};
+		39D1EEC42B0DED4900A1A779 /* AssistantView */ = {
+			isa = PBXGroup;
+			children = (
+				39D1EEC52B0DED6700A1A779 /* DetailTopView.swift */,
+				39D1EEC72B0DEEE500A1A779 /* DetailBannerImageView.swift */,
+			);
+			path = AssistantView;
 			sourceTree = "<group>";
 		};
 		39FE56722B0DA82600A17A03 /* Font */ = {
@@ -584,7 +598,6 @@
 				0057F1562B0A7C91002D06A5 /* Device.swift in Sources */,
 				D206CA682B0C7C50007ECC1B /* MainCategoryCollectionViewCell.swift in Sources */,
 				D23475E32B0A6B180098432F /* UIViewController+.swift in Sources */,
-				007BACA32B08A6ED005A34C3 /* 16.swift in Sources */,
 				0057F1542B0A6F20002D06A5 /* Image.swift in Sources */,
 				D23475CD2B0A69450098432F /* UIButton+.swift in Sources */,
 				D23475D32B0A69AA0098432F /* UIImageView+.swift in Sources */,
@@ -592,6 +605,7 @@
 				D206CA612B0C69F4007ECC1B /* MainMoreClubCollectionView.swift in Sources */,
 				D23475D12B0A699B0098432F /* UICollectionViewCell++.swift in Sources */,
 				007BAC9B2B08A6D0005A34C3 /* 12.swift in Sources */,
+				39D1EEC12B0DEA3900A1A779 /* DetailViewController.swift in Sources */,
 				007BACA72B08A6FB005A34C3 /* 18.swift in Sources */,
 				007BAC9F2B08A6E4005A34C3 /* 14.swift in Sources */,
 				007822452B089F8F008F0E17 /* AppDelegate.swift in Sources */,
@@ -599,6 +613,8 @@
 				D206CA582B0C5B9E007ECC1B /* MainViewController.swift in Sources */,
 				D23475D72B0A69C70098432F /* UINavagationController+.swift in Sources */,
 				0057F1522B0A6C83002D06A5 /* UIColor+.swift in Sources */,
+				39D1EEC32B0DEA6900A1A779 /* DetailView.swift in Sources */,
+				39D1EEC82B0DEEE500A1A779 /* DetailBannerImageView.swift in Sources */,
 				D23475DF2B0A6AFA0098432F /* UITextField+.swift in Sources */,
 				D206CA6F2B0C895E007ECC1B /* MainPostCollectionViewCell.swift in Sources */,
 				D206CA6D2B0C8930007ECC1B /* MainPostCollectionView.swift in Sources */,
@@ -611,11 +627,11 @@
 				0083B1A22B0BCAA500357725 /* ClubViewController.swift in Sources */,
 				007822472B089F8F008F0E17 /* SceneDelegate.swift in Sources */,
 				D206CA662B0C7C34007ECC1B /* MainCategoryCollectionView.swift in Sources */,
+				39D1EEC62B0DED6700A1A779 /* DetailTopView.swift in Sources */,
 				D23475E12B0A6B070098432F /* UIView+.swift in Sources */,
 				D23475D92B0A69D30098432F /* UIStackView+.swift in Sources */,
 				D23475C92B0A69220098432F /* String+.swift in Sources */,
 				D23475DD2B0A6AE60098432F /* UITableViewCell+.swift in Sources */,
-				007BACA12B08A6E8005A34C3 /* 15.swift in Sources */,
 				007BACBB2B08A79E005A34C3 /* 4.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Carrot-iOS/Carrot-iOS.xcodeproj/project.pbxproj
+++ b/Carrot-iOS/Carrot-iOS.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		39D1EEC32B0DEA6900A1A779 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D1EEC22B0DEA6900A1A779 /* DetailView.swift */; };
 		39D1EEC62B0DED6700A1A779 /* DetailTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D1EEC52B0DED6700A1A779 /* DetailTopView.swift */; };
 		39D1EEC82B0DEEE500A1A779 /* DetailBannerImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D1EEC72B0DEEE500A1A779 /* DetailBannerImageView.swift */; };
+		39D1EECA2B0E064A00A1A779 /* DetailDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D1EEC92B0E064A00A1A779 /* DetailDescriptionView.swift */; };
+		39D1EECC2B0E08F700A1A779 /* DetailTagLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D1EECB2B0E08F700A1A779 /* DetailTagLabel.swift */; };
 		39FE56752B0DA82600A17A03 /* AppleSDGothicNeo.ttc in Resources */ = {isa = PBXBuildFile; fileRef = 39FE56732B0DA82600A17A03 /* AppleSDGothicNeo.ttc */; };
 		39FE56762B0DA82600A17A03 /* SF-Pro.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 39FE56742B0DA82600A17A03 /* SF-Pro.ttf */; };
 		D206CA582B0C5B9E007ECC1B /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D206CA572B0C5B9E007ECC1B /* MainViewController.swift */; };
@@ -92,6 +94,8 @@
 		39D1EEC22B0DEA6900A1A779 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		39D1EEC52B0DED6700A1A779 /* DetailTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailTopView.swift; sourceTree = "<group>"; };
 		39D1EEC72B0DEEE500A1A779 /* DetailBannerImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailBannerImageView.swift; sourceTree = "<group>"; };
+		39D1EEC92B0E064A00A1A779 /* DetailDescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailDescriptionView.swift; sourceTree = "<group>"; };
+		39D1EECB2B0E08F700A1A779 /* DetailTagLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailTagLabel.swift; sourceTree = "<group>"; };
 		39FE56732B0DA82600A17A03 /* AppleSDGothicNeo.ttc */ = {isa = PBXFileReference; lastKnownFileType = file; path = AppleSDGothicNeo.ttc; sourceTree = "<group>"; };
 		39FE56742B0DA82600A17A03 /* SF-Pro.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SF-Pro.ttf"; sourceTree = "<group>"; };
 		D206CA572B0C5B9E007ECC1B /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
@@ -436,8 +440,10 @@
 		39D1EEC42B0DED4900A1A779 /* AssistantView */ = {
 			isa = PBXGroup;
 			children = (
-				39D1EEC52B0DED6700A1A779 /* DetailTopView.swift */,
 				39D1EEC72B0DEEE500A1A779 /* DetailBannerImageView.swift */,
+				39D1EEC52B0DED6700A1A779 /* DetailTopView.swift */,
+				39D1EEC92B0E064A00A1A779 /* DetailDescriptionView.swift */,
+				39D1EECB2B0E08F700A1A779 /* DetailTagLabel.swift */,
 			);
 			path = AssistantView;
 			sourceTree = "<group>";
@@ -591,6 +597,7 @@
 				007BAC992B08A6CC005A34C3 /* 11.swift in Sources */,
 				D23475CF2B0A695C0098432F /* UICollectionReuseableView+.swift in Sources */,
 				007822492B089F8F008F0E17 /* ViewController.swift in Sources */,
+				39D1EECA2B0E064A00A1A779 /* DetailDescriptionView.swift in Sources */,
 				D206CA712B0C991D007ECC1B /* MainClubModel.swift in Sources */,
 				D206CA642B0C6E8C007ECC1B /* MainMoreClubCollectionFooterView.swift in Sources */,
 				007BACAB2B08A711005A34C3 /* 7.swift in Sources */,
@@ -598,6 +605,7 @@
 				0057F1562B0A7C91002D06A5 /* Device.swift in Sources */,
 				D206CA682B0C7C50007ECC1B /* MainCategoryCollectionViewCell.swift in Sources */,
 				D23475E32B0A6B180098432F /* UIViewController+.swift in Sources */,
+				39D1EECC2B0E08F700A1A779 /* DetailTagLabel.swift in Sources */,
 				0057F1542B0A6F20002D06A5 /* Image.swift in Sources */,
 				D23475CD2B0A69450098432F /* UIButton+.swift in Sources */,
 				D23475D32B0A69AA0098432F /* UIImageView+.swift in Sources */,

--- a/Carrot-iOS/Carrot-iOS/Application/SceneDelegate.swift
+++ b/Carrot-iOS/Carrot-iOS/Application/SceneDelegate.swift
@@ -20,11 +20,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window = UIWindow(windowScene: windowScene)
         window?.overrideUserInterfaceStyle = .light 
         
-        let mainViewController = MainViewController()
-        let navigationController = UINavigationController(rootViewController: mainViewController)
-
-        navigationController.isNavigationBarHidden = true
-        self.window?.rootViewController = navigationController
+        let mainViewController = DetailViewController()
+//        let navigationController = UINavigationController(rootViewController: mainViewController)
+//
+//        navigationController.isNavigationBarHidden = true
+        self.window?.rootViewController = mainViewController
         self.window?.makeKeyAndVisible()
     }
     

--- a/Carrot-iOS/Carrot-iOS/Application/SceneDelegate.swift
+++ b/Carrot-iOS/Carrot-iOS/Application/SceneDelegate.swift
@@ -20,11 +20,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window = UIWindow(windowScene: windowScene)
         window?.overrideUserInterfaceStyle = .light 
         
-        let mainViewController = DetailViewController()
-//        let navigationController = UINavigationController(rootViewController: mainViewController)
-//
-//        navigationController.isNavigationBarHidden = true
-        self.window?.rootViewController = mainViewController
+        let mainViewController = MainViewController()
+        let navigationController = UINavigationController(rootViewController: mainViewController)
+
+        navigationController.isNavigationBarHidden = true
+        self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
     }
     

--- a/Carrot-iOS/Carrot-iOS/Global/Extension/UIKit+/UILabel+.swift
+++ b/Carrot-iOS/Carrot-iOS/Global/Extension/UIKit+/UILabel+.swift
@@ -36,6 +36,19 @@ extension UILabel {
         attributedText = attributeString
     }
     
+    func setLineSpacing(percentage: Double) {
+        let spacing = (self.font.pointSize * CGFloat(percentage/100) - self.font.pointSize)/2
+        guard let text = text else { return }
+        
+        let attributeString = NSMutableAttributedString(string: text)
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = spacing
+        attributeString.addAttribute(.paragraphStyle,
+                                     value: style,
+                                     range: NSRange(location: 0, length: attributeString.length))
+        attributedText = attributeString
+    }
+    
     func setAttributeLabel(targetString: [String], color: UIColor?, font: UIFont?, spacing: CGFloat = 0, baseLineOffset: CGFloat = 0) {
         let fullText = text ?? ""
         let style = NSMutableParagraphStyle()
@@ -64,6 +77,33 @@ extension UILabel {
         self.attributedText = NSAttributedString(string: text, attributes: [NSAttributedString.Key.kern: kerning])
     }
     
+    func setKerning(withPercentage value: Double) {
+        let kerning = self.font.pointSize * CGFloat(value/100)
+        guard let text = text, !text.isEmpty else { return }
+        self.attributedText = NSAttributedString(string: text, attributes: [NSAttributedString.Key.kern: kerning])
+    }
+    
+    func setLineSpacingAndKerning(spacingPercentage: Double, kerningPercentage: Double) {
+        let kerning = self.font.pointSize * CGFloat(kerningPercentage/100)
+        let spacing = (self.font.pointSize * CGFloat(spacingPercentage/100) - self.font.pointSize)/2
+        guard let text = text, !text.isEmpty else { return }
+        
+        let attributeString = NSMutableAttributedString(string: text)
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = spacing
+        attributeString.addAttribute(
+            .paragraphStyle,
+            value: style,
+            range: NSRange(location: 0, length: attributeString.length)
+        )
+        
+        attributeString.addAttribute(
+            .kern,
+            value: kerning,
+            range: NSRange(location: 0, length: attributeString.length - 1))
+        
+        attributedText = attributeString
+    }
 }
 
 extension String {

--- a/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/15.swift
+++ b/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/15.swift
@@ -1,8 +1,0 @@
-//
-//  1.swift
-//  Carrot-iOS
-//
-//  Created by 티모시 킴 on 11/18/23.
-//
-
-import Foundation

--- a/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/AssistantView/DetailBannerImageView.swift
+++ b/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/AssistantView/DetailBannerImageView.swift
@@ -12,13 +12,9 @@ import Then
 
 final class DetailBannerImageView: UIView {
     
-    // MARK: - Properties
-    
-    
     // MARK: - UI Components
     
     private let bannerImageView = UIImageView()
-    
     
     // MARK: - Life Cycle
     

--- a/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/AssistantView/DetailBannerImageView.swift
+++ b/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/AssistantView/DetailBannerImageView.swift
@@ -1,0 +1,54 @@
+//
+//  DetailBannerImageView.swift
+//  Carrot-iOS
+//
+//  Created by 이윤학 on 11/22/23.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class DetailBannerImageView: UIView {
+    
+    // MARK: - Properties
+    
+    
+    // MARK: - UI Components
+    
+    private let bannerImageView = UIImageView()
+    
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        style()
+        hieararchy()
+        layout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Custom Method
+    
+    private func style() {
+        bannerImageView.do {
+            $0.image = .img27
+        }
+    }
+    
+    private func hieararchy() {
+        self.addSubviews(bannerImageView)
+    }
+    
+    private func layout() {
+        bannerImageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}

--- a/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/AssistantView/DetailDescriptionView.swift
+++ b/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/AssistantView/DetailDescriptionView.swift
@@ -1,0 +1,110 @@
+//
+//  DetailDescriptionView.swift
+//  Carrot-iOS
+//
+//  Created by 이윤학 on 11/22/23.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class DetailDescriptionView: UIView {
+    
+    // MARK: - Properties
+    
+    
+    // MARK: - UI Components
+    
+    private let upperStackView = UIStackView()
+    
+    private let tagStackView = UIStackView()
+    private let tag1 = DetailTagLabel()
+    private let tag2 = DetailTagLabel()
+
+    private let descriptionLabel = UILabel()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        style()
+        hieararchy()
+        layout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Custom Method
+    
+    private func style() {
+        upperStackView.do {
+            $0.axis = .vertical
+            $0.spacing = 10
+            $0.alignment = .fill
+            $0.layoutMargins = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 15)
+            $0.isLayoutMarginsRelativeArrangement = true
+        }
+        
+        tagStackView.do {
+            $0.axis = .horizontal
+            $0.spacing = 9
+            $0.alignment = .leading
+        }
+        
+        tag1.do {
+            $0.text = "운동"
+            $0.font = .carrotBody
+            $0.textColor = .grey500
+            $0.makeCornerRound(radius: 4)
+            $0.backgroundColor = .grey100
+        }
+        
+        tag2.do {
+            $0.text = "23~53세"
+            $0.font = .carrotBody
+            $0.textColor = .grey500
+            $0.makeCornerRound(radius: 4)
+            $0.backgroundColor = .grey100
+        }
+        
+        descriptionLabel.do {
+            $0.text = """
+            우리 동네 테니스 모임(수지)
+            상시회원 모집
+            *20~50대 게임(주로 복식) 가능하신 분
+            *주소가 용인에 거주 하시는 분
+            *주 코트 위치: 신봉동(고가다리밑), 성복동(배수지코트), 풍덕천동(
+            수지체육공원)
+            *회비 없음 (유료 코트시 n/1)
+            *회원간 예약 후 원하시는 시간에 자유롭게 운동 합니다
+            """
+            $0.numberOfLines = 0
+            $0.font = .carrotBody
+            $0.textColor = .carrotBlack
+            $0.setLineSpacingAndKerning(spacingPercentage: 160, kerningPercentage: -4.3)
+        }
+    }
+    
+    private func hieararchy() {
+        self.addSubviews(upperStackView)
+        
+        upperStackView.addArrangedSubViews(
+            tagStackView, descriptionLabel
+        )
+        
+        tagStackView.addArrangedSubViews(
+            tag1, tag2, UIView()   // 마지막 view 가 늘어나므로, 더미 뷰를 넣어줭주었음.
+        )
+    }
+    
+    private func layout() {
+        upperStackView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}

--- a/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/AssistantView/DetailDescriptionView.swift
+++ b/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/AssistantView/DetailDescriptionView.swift
@@ -12,9 +12,6 @@ import Then
 
 final class DetailDescriptionView: UIView {
     
-    // MARK: - Properties
-    
-    
     // MARK: - UI Components
     
     private let upperStackView = UIStackView()
@@ -22,7 +19,7 @@ final class DetailDescriptionView: UIView {
     private let tagStackView = UIStackView()
     private let tag1 = DetailTagLabel()
     private let tag2 = DetailTagLabel()
-
+    
     private let descriptionLabel = UILabel()
     
     // MARK: - Life Cycle

--- a/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/AssistantView/DetailTagLabel.swift
+++ b/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/AssistantView/DetailTagLabel.swift
@@ -1,0 +1,29 @@
+//
+//  DetailTagLabel.swift
+//  Carrot-iOS
+//
+//  Created by 이윤학 on 11/22/23.
+//
+
+import UIKit
+
+class DetailTagLabel: UILabel {
+    private var padding = UIEdgeInsets(top: 4, left: 8, bottom: 4, right: 8)
+
+    convenience init(padding: UIEdgeInsets) {
+        self.init()
+        self.padding = padding
+    }
+
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: padding))
+    }
+
+    override var intrinsicContentSize: CGSize {
+        var contentSize = super.intrinsicContentSize
+        contentSize.height += padding.top + padding.bottom
+        contentSize.width += padding.left + padding.right
+
+        return contentSize
+    }
+}

--- a/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/AssistantView/DetailTopView.swift
+++ b/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/AssistantView/DetailTopView.swift
@@ -20,7 +20,17 @@ final class DetailTopView: UIView {
     private let upperStackView = UIStackView()
     
     private let firstStackView = UIStackView()
+    private let thumbnailView = UIImageView()
+    private let innerStackView = UIStackView()
+    private let shareButton = UIButton()
+    private let moreButton = UIButton()
     
+    private let titleView = UILabel()
+    
+    private let moreMemberButton = UIButton()
+    private let buttonStackView = UIStackView()
+    private let buttontitle = UILabel()
+    private let buttonImage = UIImageView()
     
     // MARK: - Life Cycle
     
@@ -42,22 +52,98 @@ final class DetailTopView: UIView {
         upperStackView.do {
             $0.axis = .vertical
             $0.spacing = 16
+            $0.alignment = .fill
+            $0.layoutMargins = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 15)
+            $0.isLayoutMarginsRelativeArrangement = true
         }
         
         firstStackView.do {
             $0.axis = .horizontal
             $0.distribution = .equalSpacing
+            $0.alignment = .bottom
+        }
+        
+        thumbnailView.do {
+            $0.image = .img28
+            $0.makeCornerRound(radius: 14)
+        }
+        
+        innerStackView.do {
+            $0.axis = .horizontal
+            $0.spacing = 9
+        }
+        
+        shareButton.do {
+            $0.setImage(.icShareCircle, for: .normal)
+        }
+        moreButton.do {
+            $0.setImage(.icMeatballCircle, for: .normal)
+        }
+        
+        titleView.do {
+            $0.text = "[수지] 테니스 치실 동네분들 모십니다 ^^"
+            $0.font = .carrotHead
+            $0.textColor = .carrotBlack
+        }
+        
+        moreMemberButton.do {
+            $0.backgroundColor = .primaryBackground
+            $0.layer.cornerRadius = 6
+        }
+        
+        buttonStackView.do {
+            $0.axis = .horizontal
+            $0.spacing = 6
+        }
+        
+        buttontitle.do {
+            $0.text = "40명의 멤버 보기"
+            $0.font = .carrotSubtitle
+            $0.textColor = .primaryButton
+        }
+        
+        buttonImage.do {
+            $0.image = .icNavigationRight.withRenderingMode(.alwaysTemplate)
+            $0.tintColor = .primaryButton
         }
         
     }
     
     private func hieararchy() {
         self.addSubviews(upperStackView)
+        
+        upperStackView.addArrangedSubViews(
+            firstStackView, titleView, moreMemberButton
+        )
+        
+        firstStackView.addArrangedSubViews(
+            thumbnailView, innerStackView
+        )
+        
+        innerStackView.addArrangedSubViews(
+            shareButton, moreButton
+        )
+        
+        moreMemberButton.addSubviews(
+            buttonStackView
+        )
+        
+        buttonStackView.addArrangedSubViews(
+            buttontitle, buttonImage
+        )
     }
     
     private func layout() {
         upperStackView.snp.makeConstraints {
             $0.edges.equalToSuperview()
+        }
+        
+        moreMemberButton.snp.makeConstraints {
+            $0.height.equalTo(41)
+        }
+        
+        buttonStackView.snp.makeConstraints {
+            $0.centerX.centerY.equalToSuperview()
         }
     }
 }

--- a/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/AssistantView/DetailTopView.swift
+++ b/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/AssistantView/DetailTopView.swift
@@ -1,0 +1,63 @@
+//
+//  DetailTopView.swift
+//  Carrot-iOS
+//
+//  Created by 이윤학 on 11/22/23.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class DetailTopView: UIView {
+    
+    // MARK: - Properties
+    
+    
+    // MARK: - UI Components
+    
+    private let upperStackView = UIStackView()
+    
+    private let firstStackView = UIStackView()
+    
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        style()
+        hieararchy()
+        layout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Custom Method
+    
+    private func style() {
+        upperStackView.do {
+            $0.axis = .vertical
+            $0.spacing = 16
+        }
+        
+        firstStackView.do {
+            $0.axis = .horizontal
+            $0.distribution = .equalSpacing
+        }
+        
+    }
+    
+    private func hieararchy() {
+        self.addSubviews(upperStackView)
+    }
+    
+    private func layout() {
+        upperStackView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}

--- a/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/AssistantView/DetailTopView.swift
+++ b/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/AssistantView/DetailTopView.swift
@@ -12,9 +12,6 @@ import Then
 
 final class DetailTopView: UIView {
     
-    // MARK: - Properties
-    
-    
     // MARK: - UI Components
     
     private let upperStackView = UIStackView()

--- a/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/DetailView.swift
+++ b/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/DetailView.swift
@@ -23,14 +23,15 @@ final class DetailView: UIView {
     
     private let bannerImageView = DetailBannerImageView()
     private let topView = DetailTopView()
+    private let descriptionView = DetailDescriptionView()
     
     // MARK: - Life Cycle
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        style()
         hieararchy()
+        style()
         layout()
     }
     
@@ -48,6 +49,8 @@ final class DetailView: UIView {
         scrollContentView.do {
             $0.axis = .vertical
             $0.alignment = .fill
+            $0.setCustomSpacing(-20, after: bannerImageView)
+            $0.setCustomSpacing(26, after: topView)
         }
     }
     
@@ -57,7 +60,7 @@ final class DetailView: UIView {
         pageScrollView.addSubviews(scrollContentView)
         
         scrollContentView.addArrangedSubViews(
-            bannerImageView, topView
+            bannerImageView, topView, descriptionView
         )
     }
     
@@ -69,10 +72,6 @@ final class DetailView: UIView {
         scrollContentView.snp.makeConstraints {
             $0.edges.equalToSuperview()
             $0.width.equalToSuperview()
-        }
-        
-        topView.snp.makeConstraints {
-            $0.top.equalTo(bannerImageView.snp.bottom).offset(-20)
         }
     }
 }

--- a/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/DetailView.swift
+++ b/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/DetailView.swift
@@ -1,0 +1,65 @@
+//
+//  DetailView.swift
+//  Carrot-iOS
+//
+//  Created by 이윤학 on 11/22/23.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class DetailView: UIView {
+    
+    // MARK: - Properties
+    
+    
+    
+    // MARK: - UI Components
+    
+    private let pageScrollView = UIScrollView()
+    private let scrollContentView = UIStackView()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        style()
+        hieararchy()
+        layout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Custom Method
+    
+    private func style() {
+        self.do {
+            $0.backgroundColor = .carrotWhite
+        }
+    }
+    
+    private func hieararchy() {
+        self.addSubviews(pageScrollView)
+        
+        pageScrollView.addSubviews(scrollContentView)
+        
+        scrollContentView.addArrangedSubViews(
+            
+        )
+    }
+    
+    private func layout() {
+        pageScrollView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        scrollContentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.width.equalToSuperview()
+        }
+    }
+}

--- a/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/DetailView.swift
+++ b/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/DetailView.swift
@@ -11,11 +11,7 @@ import SnapKit
 import Then
 
 final class DetailView: UIView {
-    
-    // MARK: - Properties
-    
-    
-    
+
     // MARK: - UI Components
     
     private let pageScrollView = UIScrollView()

--- a/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/DetailView.swift
+++ b/Carrot-iOS/Carrot-iOS/Presentation/Detail/View/DetailView.swift
@@ -21,6 +21,9 @@ final class DetailView: UIView {
     private let pageScrollView = UIScrollView()
     private let scrollContentView = UIStackView()
     
+    private let bannerImageView = DetailBannerImageView()
+    private let topView = DetailTopView()
+    
     // MARK: - Life Cycle
     
     override init(frame: CGRect) {
@@ -41,6 +44,11 @@ final class DetailView: UIView {
         self.do {
             $0.backgroundColor = .carrotWhite
         }
+        
+        scrollContentView.do {
+            $0.axis = .vertical
+            $0.alignment = .fill
+        }
     }
     
     private func hieararchy() {
@@ -49,7 +57,7 @@ final class DetailView: UIView {
         pageScrollView.addSubviews(scrollContentView)
         
         scrollContentView.addArrangedSubViews(
-            
+            bannerImageView, topView
         )
     }
     
@@ -57,9 +65,14 @@ final class DetailView: UIView {
         pageScrollView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
+        
         scrollContentView.snp.makeConstraints {
             $0.edges.equalToSuperview()
             $0.width.equalToSuperview()
+        }
+        
+        topView.snp.makeConstraints {
+            $0.top.equalTo(bannerImageView.snp.bottom).offset(-20)
         }
     }
 }

--- a/Carrot-iOS/Carrot-iOS/Presentation/Detail/ViewController/16.swift
+++ b/Carrot-iOS/Carrot-iOS/Presentation/Detail/ViewController/16.swift
@@ -1,8 +1,0 @@
-//
-//  1.swift
-//  Carrot-iOS
-//
-//  Created by 티모시 킴 on 11/18/23.
-//
-
-import Foundation

--- a/Carrot-iOS/Carrot-iOS/Presentation/Detail/ViewController/DetailViewController.swift
+++ b/Carrot-iOS/Carrot-iOS/Presentation/Detail/ViewController/DetailViewController.swift
@@ -1,0 +1,34 @@
+//
+//  DetailViewController.swift
+//  Carrot-iOS
+//
+//  Created by 이윤학 on 11/22/23.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class DetailViewController: UIViewController {
+    
+    //MARK: - UI Components
+    
+    private let rootView = DetailView()
+    
+    //MARK: - Life Cycle
+    
+    override func loadView() {
+        self.view = rootView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        delegate()
+    }
+    
+    private func delegate() {
+        
+    }
+}


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #24 

### ✅ 작업한 내용
- 최상위 계층의 스크롤 뷰, StackView 생성
- 최상단 ImageView 추가
- 중간의 제목, 썸네일 뷰 추가
- 하단의 모임 태그, 상세 내용 뷰 추가
- 
### ❗️PR Point
- 행간과 자간이 현재 extension 함수로는 동시에 적용이 불가능해, 둘을 같이 설정하는 함수를 추가했습니다.
- 퍼센트로 입력할 수 있도록 해두었습니다.
- 최대한 StackView를 활용해 레이아웃을 짜보았더니, 직접 제약조건을 주는 부분이 많이 줄어들었습니다.

### 📸 스크린샷
![Simulator Screenshot - iPhone 15 Pro - 2023-11-23 at 01 53 39](https://github.com/DOSOPT-CDS-APP-TEAM5/Carrot-iOS/assets/87518742/435a3ef6-1247-45f1-bd51-dd0a4f138c31)

closed #24 